### PR TITLE
5715: api/upload_photo responds with {“submission_id” : 1} instead of…

### DIFF
--- a/platemate/food/views.py
+++ b/platemate/food/views.py
@@ -327,7 +327,7 @@ def api_photo_upload(request):
         )
         s.save()
 
-        data = dict({"photo_id" : p.id})
+        data = dict({"submission_id" : s.id})
 
         return JsonResponse(data)
     except ValueError:


### PR DESCRIPTION
… the photo id. Manually tested on local. This update is in light of understanding how this story fits with 5716 and 5717. 