### PR TITLE
6272 patch crash when no response

### DIFF
--- a/platemate/management/models/turk.py
+++ b/platemate/management/models/turk.py
@@ -108,7 +108,7 @@ class Assignment(SmartModel):
             for r in responses:
                 if r.valid is False:
                     return r.feedback
-            return responses[0].feedack
+            return responses[0].feedback
 
 class Response(SmartModel):
     assignment = ForeignKey('Assignment',related_name='responses')

--- a/platemate/management/models/turk.py
+++ b/platemate/management/models/turk.py
@@ -103,7 +103,7 @@ class Assignment(SmartModel):
     def feedback(self):
         responses = self.responses.all()
         if not responses:
-            return "No response found."
+            return "You didn't provide any response."
         else:
             for r in responses:
                 if r.valid is False:

--- a/platemate/management/models/turk.py
+++ b/platemate/management/models/turk.py
@@ -91,17 +91,24 @@ class Assignment(SmartModel):
     # Returns True if all responses are valid
     @property
     def valid(self):
-        for r in self.responses.all():
+        responses = self.responses.all()
+        if not responses:
+            return False
+        for r in responses:
             if not r.valid:
                 return r.valid
         return True
 
     @property
     def feedback(self):
-        for r in self.responses.all():
-            if r.valid is False:
-                return r.feedback
-        return self.responses.all()[0].feedback
+        responses = self.responses.all()
+        if not responses:
+            return "No response found."
+        else:
+            for r in responses:
+                if r.valid is False:
+                    return r.feedback
+            return responses[0].feedack
 
 class Response(SmartModel):
     assignment = ForeignKey('Assignment',related_name='responses')


### PR DESCRIPTION
This is just the two new guard clauses we talked about. Tested with prod db on local and it rejected the HIT without a response, created new HITs, and continued in the loop. 

You'll see `if not list` which is apparently the 'pythonic' way to check for an empty list according to python docs. 